### PR TITLE
releasetools: don't assert device

### DIFF
--- a/tools/releasetools/edify_generator.py
+++ b/tools/releasetools/edify_generator.py
@@ -145,13 +145,7 @@ class EdifyGenerator(object):
 
   def AssertDevice(self, device):
     """Assert that the device identifier is the given string."""
-    cmd = ('assert(' +
-           ' || \0'.join(['getprop("ro.product.device") == "%s" || getprop("ro.build.product") == "%s"'
-                         % (i, i) for i in device.split(",")]) +
-           ' || abort("E%d: This package is for device: %s; ' +
-           'this device is " + getprop("ro.product.device") + ".");' +
-           ');') % (common.ErrorCode.DEVICE_MISMATCH, device)
-    self.script.append(self.WordWrap(cmd))
+    pass
 
   def AssertSomeBootloader(self, *bootloaders):
     """Assert that the bootloader version is one of *bootloaders."""


### PR DESCRIPTION
* This issue is there in lettuce; without this the build doesnt get flashed (returns error 7). (See commit message for more details)
* And anyways there wont be people who are blind enough to flash wrong device's build.