### PR TITLE
core: Fix dex pre opt build with ims

### DIFF
--- a/core/dex_preopt_libart_boot.mk
+++ b/core/dex_preopt_libart_boot.mk
@@ -119,7 +119,7 @@ $($(my_2nd_arch_prefix)DEFAULT_DEX_PREOPT_BUILT_IMAGE_FILENAME) : $(LIBART_TARGE
 		--no-generate-debug-info --generate-build-id \
 		--multi-image --no-inline-from=core-oj.jar \
 		--abort-on-hard-verifier-error \
-		--abort-on-soft-verifier-error \
+#		--abort-on-soft-verifier-error \
 		$(PRODUCT_DEX_PREOPT_BOOT_FLAGS) $(GLOBAL_DEXPREOPT_FLAGS) $(ART_BOOT_IMAGE_EXTRA_ARGS) \
 		|| ( echo "$(DEX2OAT_FAILURE_MESSAGE)" ; false ) && \
 	$(DEX2OAT_BOOT_IMAGE_LOG_TAGS) ANDROID_ROOT=$(PRODUCT_OUT)/system ANDROID_DATA=$(dir $@) $(PATCHOAT) \


### PR DESCRIPTION
Faced this yesterday on 2 clean synced builds, each for lettuce and A6020, at 99%:

`dex2oat F 10-31 02:27:52  4964  4964 compiler_driver.cc:942] Had 2 soft failure(s) verifying all classes, and was aske
d to abort in such situations. Please check the log.
ERROR: Dex2oat failed to compile a boot image. It is likely that the boot classpath is inconsistent. Rebuild with ART_
BOOT_IMAGE_EXTRA_ARGS=--runtime-arg -verbose:verifier to see verification errors.`