### PR TITLE
[SQUASH][DNM] Merge tag 'android-9.0.0_r35' into staging/lineage-16.0…

### DIFF
--- a/core/build_id.mk
+++ b/core/build_id.mk
@@ -18,4 +18,4 @@
 # (like "CRB01").  It must be a single word, and is
 # capitalized by convention.
 
-export BUILD_ID=PQ2A.190305.002
+export BUILD_ID=PQ2A.190405.003

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -231,7 +231,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2019-03-05
+      PLATFORM_SECURITY_PATCH := 2019-04-05
 endif
 
 ifndef PLATFORM_SECURITY_PATCH_TIMESTAMP


### PR DESCRIPTION
…_merge-android-9.0.0_r35

Android 9.0.0 release 35

* tag 'android-9.0.0_r35':
  Update Security String to 2019-04-05 Bug: 124119313 (cherry picked from commit 0b5a344dc3b1f13b69983a711467dbe94251011a)
  Version bump to PQ2A.190405.002
  Version bump to PQ2A.190405.001
  Version bump to PQ2A.190401.002
  Version bump to PQ2A.190401.001
  Update Security String to 2019-04-01 Bug: 124119313 (cherry picked from commit f9835d9f4d39c78ddf35899b058498f1908e906e)

Change-Id: I05af36c6c1c43dca7e501865aa8f9c64486cc82c