### PR TITLE
Google patches: Fix coredump_enable() in envsetup.sh

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1046,7 +1046,7 @@ function coredump_enable()
         return;
     fi;
     echo "Setting core limit for $PID to infinite...";
-    adb shell /system/bin/ulimit -p $PID -c unlimited
+    adb shell /system/bin/ulimit -P $PID -c unlimited
 }
 
 # core - send SIGV and pull the core for process

--- a/tools/check_elf_file.py
+++ b/tools/check_elf_file.py
@@ -72,9 +72,9 @@ ELF = collections.namedtuple(
 
 def _get_os_name():
   """Get the host OS name."""
-  if sys.platform == 'linux2':
+  if sys.platform.startswith('linux'):
     return 'linux'
-  if sys.platform == 'darwin':
+  if sys.platform.startswith('darwin'):
     return 'darwin'
   raise ValueError(sys.platform + ' is not supported')
 


### PR DESCRIPTION
-P means PID to affect (default $PPID), while -p means Pipe buffer (512 bytes), we should use -P here.

Bug: 234049197

Test: Perform ". build/envsetup.sh" in host, then run "coredump_enable $PID".

Change-Id: Id373f2a7adc56d6a40720ec900b2561c9dbea2b1