### PR TITLE
envsetup: Set INLINE_KERNEL_BUILDING if EMULATOR_KERNEL_FILE is set

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -883,7 +883,8 @@ function lunch()
     fi
 
     local prebuilt_kernel=$(get_build_var TARGET_PREBUILT_KERNEL)
-    if [ -z "$prebuilt_kernel" ]; then
+    local emulator_kernel=$(get_build_var EMULATOR_KERNEL_FILE)
+    if [ -z "$prebuilt_kernel" ] || [ -z "$emulator_kernel" ]; then
       export INLINE_KERNEL_BUILDING=true
     else
       unset INLINE_KERNEL_BUILDING


### PR DESCRIPTION
* Fixes the following build failure when building emulator targets:

FAILED: out/soong/build.ninja
cd "$(dirname "out/host/linux-x86/bin/soong_build")" && BUILDER="$PWD/$(basename "out/host/linux-x86/bin/soong_build")" && cd / && env -i  "$BUILDER"     --top "$TOP"     --soong_out "out/soong"     --out "out"     -o out/soong/build.ninja --bazel-mode --globListDir build --globFile out/soong/globs-build.ninja -t -l out/.module_paths/Android.bp.list --available_env out/soong/soong.environment.available --used_env out/soong/soong.environment.used.build Android.bp
error: vendor/qcom/opensource/dataservices/rmnetctl/Android.bp:34:1: "librmnetctl" depends on undefined module "qti_kernel_headers".
Module "librmnetctl" is defined in namespace "vendor/qcom/opensource/dataservices" which can read these 2 namespaces: ["vendor/qcom/opensource/dataservices" "."]
Module "qti_kernel_headers" can be found in these namespaces: ["hardware/google/pixel"]
Or did you mean ["device_kernel_headers" "kernel_log_monitor" "libkernel_cmdline" "qti_powerhal_headers"]?
21:42:24 soong bootstrap failed with: exit status 1

Change-Id: I5a1f735077601871093747a23a9040ecce2cf4c7