### PR TITLE
Revert "envsetup: Set INLINE_KERNEL_BUILDING if EMULATOR_KERNEL_FILE …

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -883,8 +883,7 @@ function lunch()
     fi
 
     local prebuilt_kernel=$(get_build_var TARGET_PREBUILT_KERNEL)
-    local emulator_kernel=$(get_build_var EMULATOR_KERNEL_FILE)
-    if [ -z "$prebuilt_kernel" ] || [ -z "$emulator_kernel" ]; then
+    if [ -z "$prebuilt_kernel" ]; then
       export INLINE_KERNEL_BUILDING=true
     else
       unset INLINE_KERNEL_BUILDING


### PR DESCRIPTION
…is set"

Reason for revert: Breaks Pixel build, not needed anymore after https://github.com/LineageOS/android_vendor_lineage/commit/f0b1169abd007a6c3417270047297b942e727553

This reverts commit c93afb5bfaa3cfde38c34bbaef3b748a4cbd7e9d.

Change-Id: Ia3ead9576a647eeff01a943d6543a82e955b4050