### PR TITLE
T_asb_2024-06

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -6629,7 +6629,7 @@ ifeq (true,$(PRODUCT_BUILD_SUPER_PARTITION))
 # BOARD_SUPER_PARTITION_SIZE must be defined to build super image.
 ifneq ($(BOARD_SUPER_PARTITION_SIZE),)
 
-ifneq (true,$(PRODUCT_RETROFIT_DYNAMIC_PARTITIONS))
+ifeq ($(words $(BOARD_SUPER_PARTITION_BLOCK_DEVICES)),1)
 
 # For real devices and for dist builds, build super image from target files to an intermediate directory.
 INTERNAL_SUPERIMAGE_DIST_TARGET := $(call intermediates-dir-for,PACKAGING,super.img)/super.img
@@ -6647,7 +6647,7 @@ endif
 .PHONY: superimage_dist
 superimage_dist: $(INTERNAL_SUPERIMAGE_DIST_TARGET)
 
-endif # PRODUCT_RETROFIT_DYNAMIC_PARTITIONS != "true"
+endif # $(words $(BOARD_SUPER_PARTITION_BLOCK_DEVICES)) == 1
 endif # BOARD_SUPER_PARTITION_SIZE != ""
 endif # PRODUCT_BUILD_SUPER_PARTITION == "true"
 
@@ -6656,7 +6656,7 @@ endif # PRODUCT_BUILD_SUPER_PARTITION == "true"
 
 ifeq (true,$(PRODUCT_BUILD_SUPER_PARTITION))
 ifneq ($(BOARD_SUPER_PARTITION_SIZE),)
-ifneq (true,$(PRODUCT_RETROFIT_DYNAMIC_PARTITIONS))
+ifeq ($(words $(BOARD_SUPER_PARTITION_BLOCK_DEVICES)),1)
 
 # Build super.img by using $(INSTALLED_*IMAGE_TARGET) to $(1)
 # $(1): built image path
@@ -6711,7 +6711,7 @@ superimage-nodeps supernod: | $(INSTALLED_SUPERIMAGE_DEPENDENCIES)
 	$(call build-superimage-target,$(INSTALLED_SUPERIMAGE_TARGET),\
 	  $(call intermediates-dir-for,PACKAGING,superimage-nodeps)/misc_info.txt)
 
-endif # PRODUCT_RETROFIT_DYNAMIC_PARTITIONS != "true"
+endif # $(words $(BOARD_SUPER_PARTITION_BLOCK_DEVICES)) == 1
 endif # BOARD_SUPER_PARTITION_SIZE != ""
 endif # PRODUCT_BUILD_SUPER_PARTITION == "true"
 

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -103,7 +103,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-    PLATFORM_SECURITY_PATCH := 2024-05-05
+    PLATFORM_SECURITY_PATCH := 2024-06-05
 endif
 
 include $(BUILD_SYSTEM)/version_util.mk

--- a/tools/releasetools/add_img_to_target_files.py
+++ b/tools/releasetools/add_img_to_target_files.py
@@ -667,6 +667,10 @@ def AddSuperEmpty(output_zip):
   build_super_image.BuildSuperImage(OPTIONS.info_dict, img.name)
   img.Write()
 
+  unsparse_img = OutputFile(output_zip, OPTIONS.input_tmp, "IMAGES", "unsparse_super_empty.img")
+  build_super_image.BuildSuperImage(OPTIONS.info_dict, unsparse_img.name, force_non_sparse=True)
+  unsparse_img.Write()
+
 
 def AddSuperSplit(output_zip):
   """Create split super_*.img and store it in output_zip."""

--- a/tools/releasetools/build_image.py
+++ b/tools/releasetools/build_image.py
@@ -513,9 +513,15 @@ def BuildImage(in_dir, prop_dict, out_file, target_out=None):
       "partition_size" not in prop_dict):
     # If partition_size is not defined, use output of `du' + reserved_size.
     # For compressed file system, it's better to use the compressed size to avoid wasting space.
-    if fs_type.startswith("erofs"):
-      mkfs_output = BuildImageMkfs(in_dir, prop_dict, out_file, target_out, fs_config)
-      if "erofs_sparse_flag" in prop_dict and not disable_sparse:
+    if fs_type.startswith("erofs") or fs_type.startswith("squash"):
+      mkfs_output = BuildImageMkfs(
+          in_dir, prop_dict, out_file, target_out, fs_config)
+      sparse_flag = False
+      if fs_type.startswith("erofs") and "erofs_sparse_flag" in prop_dict:
+        sparse_flag = True
+      if fs_type.startswith("squash") and "squashfs_sparse_flag" in prop_dict:
+        sparse_flag = True
+      if sparse_flag and not disable_sparse:
         image_path = UnsparseImage(out_file, replace=False)
         size = GetDiskUsage(image_path)
         os.remove(image_path)

--- a/tools/releasetools/build_super_image.py
+++ b/tools/releasetools/build_super_image.py
@@ -69,7 +69,7 @@ def GetArgumentsForImage(partition, group, image=None):
   return cmd
 
 
-def BuildSuperImageFromDict(info_dict, output):
+def BuildSuperImageFromDict(info_dict, output, force_non_sparse=False):
 
   cmd = [info_dict["lpmake"],
          "--metadata-size", "65536",
@@ -133,7 +133,7 @@ def BuildSuperImageFromDict(info_dict, output):
 
       cmd += GetArgumentsForImage(partition + "_b", group + "_b", other_image)
 
-  if info_dict.get("build_non_sparse_super_partition") != "true":
+  if info_dict.get("build_non_sparse_super_partition") != "true" and not force_non_sparse:
     cmd.append("--sparse")
 
   cmd += ["--output", output]
@@ -178,11 +178,11 @@ def BuildSuperImageFromTargetFiles(inp, out):
   return BuildSuperImageFromExtractedTargetFiles(input_tmp, out)
 
 
-def BuildSuperImage(inp, out):
+def BuildSuperImage(inp, out, force_non_sparse=False):
 
   if isinstance(inp, dict):
     logger.info("Building super image from info dict...")
-    return BuildSuperImageFromDict(inp, out)
+    return BuildSuperImageFromDict(inp, out, force_non_sparse=False)
 
   if isinstance(inp, str):
     if os.path.isdir(inp):

--- a/tools/releasetools/build_super_image.py
+++ b/tools/releasetools/build_super_image.py
@@ -62,7 +62,7 @@ def GetArgumentsForImage(partition, group, image=None):
   image_size = sparse_img.GetImagePartitionSize(image) if image else 0
 
   cmd = ["--partition",
-         "{}:readonly:{}:{}".format(partition, image_size, group)]
+         "{}:none:{}:{}".format(partition, image_size, group)]
   if image:
     cmd += ["--image", "{}={}".format(partition, image)]
 

--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -3724,6 +3724,9 @@ class DynamicPartitionsDifference(object):
     if progress_dict is None:
       progress_dict = {}
 
+    self._have_super_empty = \
+      info_dict.get("build_super_empty_partition") == "true"
+
     self._build_without_vendor = build_without_vendor
     self._remove_all_before_apply = False
     if source_info_dict is None:
@@ -3821,8 +3824,13 @@ class DynamicPartitionsDifference(object):
     ZipWrite(output_zip, op_list_path, "dynamic_partitions_op_list")
 
     script.Comment('Update dynamic partition metadata')
-    script.AppendExtra('assert(update_dynamic_partitions('
-                       'package_extract_file("dynamic_partitions_op_list")));')
+    if self._have_super_empty:
+      script.AppendExtra('assert(update_dynamic_partitions('
+                        'package_extract_file("dynamic_partitions_op_list"), '
+                        'package_extract_file("unsparse_super_empty.img")));')
+    else:
+      script.AppendExtra('assert(update_dynamic_partitions('
+                        'package_extract_file("dynamic_partitions_op_list")));')
 
     if write_verify_script:
       for p, u in self._partition_updates.items():

--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -3589,15 +3589,16 @@ def MakeRecoveryPatch(input_dir, output_sink, recovery_img, boot_img,
 
   full_recovery_image = info_dict.get("full_recovery_image") == "true"
   board_uses_vendorimage = info_dict.get("board_uses_vendorimage") == "true"
+  board_builds_vendorimage =  info_dict.get("board_builds_vendorimage") == "true"
 
-  if board_uses_vendorimage:
-    # In this case, the output sink is rooted at VENDOR
-    recovery_img_path = "etc/recovery.img"
+  recovery_img_path = "etc/recovery.img"
+  if board_builds_vendorimage:
     recovery_resource_dat_path = "VENDOR/etc/recovery-resource.dat"
-  else:
-    # In this case the output sink is rooted at SYSTEM
-    recovery_img_path = "vendor/etc/recovery.img"
+  elif not board_uses_vendorimage:
     recovery_resource_dat_path = "SYSTEM/vendor/etc/recovery-resource.dat"
+  else:
+    logger.warning('Recovery patch generation is disable when prebuilt vendor image is used.')
+    return None
 
   if full_recovery_image:
     output_sink(recovery_img_path, recovery_img.data)

--- a/tools/releasetools/non_ab_ota.py
+++ b/tools/releasetools/non_ab_ota.py
@@ -245,6 +245,15 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
   progress_dict["system"] = system_progress
 
   if target_info.get('use_dynamic_partitions') == "true":
+    # Add non-sparse super empty image to OTA package if it exists
+    if target_info.get('build_super_empty_partition') == "true":
+      unsparse_super_empty_image_name = "unsparse_super_empty.img"
+      unsparse_super_empty_image_path = os.path.join(OPTIONS.input_tmp, "IMAGES",
+          unsparse_super_empty_image_name)
+      unsparse_super_empty_image = common.File.FromLocalFile(
+          unsparse_super_empty_image_name, unsparse_super_empty_image_path)
+      common.ZipWriteStr(output_zip, unsparse_super_empty_image_name,
+          unsparse_super_empty_image.data)
     # Use empty source_info_dict to indicate that all partitions / groups must
     # be re-added.
     dynamic_partitions_diff = common.DynamicPartitionsDifference(


### PR DESCRIPTION
Still probably needs testing, but no complaints from the couple of my users still using A13 yet.

Also contains the patch that allows correct size calculation when using squashfs for compressed filesystem in dynamic partition image, which has worked great in Android 14 for months now.