### PR TITLE
build: allow to choose if DeviceAsWebcam is built

### DIFF
--- a/target/product/handheld_system.mk
+++ b/target/product/handheld_system.mk
@@ -44,7 +44,6 @@ PRODUCT_PACKAGES += \
     CaptivePortalLogin \
     CertInstaller \
     CredentialManager \
-    DeviceAsWebcam \
     DocumentsUI \
     DownloadProviderUi \
     EasterEgg \
@@ -72,6 +71,11 @@ PRODUCT_PACKAGES += \
     UserDictionaryProvider \
     VpnDialogs \
     vr \
+
+ifneq ($(TARGET_BUILD_DEVICE_AS_WEBCAM),false)
+    PRODUCT_PACKAGES += \
+        DeviceAsWebcam
+endif
 
 PRODUCT_PACKAGES += $(RELEASE_PACKAGE_VIRTUAL_CAMERA)
 # Set virtual_camera_service_enabled soong config variable based on the


### PR DESCRIPTION
Reopened PR. Tested on Pixel 2 Series where didn't implemented device trees/kernel adaptation. I'd rather choose to not include DeviceAsWebcam, so let me choose this