### PR TITLE
fix: remove_broken_build_tools handle missing files gracefully

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1235,16 +1235,22 @@ function setup_ccache() {
 }
 
 function remove_broken_build_tools() {
-    for file in prebuilts/build-tools/path/*/date; do
-        if [ -e "$file" ]; then
-            rm -rf "$file"
-        fi
-    done
-    for file in prebuilts/build-tools/path/*/tar; do
-        if [ -e "$file" ]; then
-            rm -rf "$file"
-        fi
-    done
+    # Check for files matching each pattern and delete if they exist, otherwise print "skipping"
+    if ls prebuilts/build-tools/path/*/date >/dev/null 2>&1; then
+        for file in prebuilts/build-tools/path/*/date; do
+            rm -f "$file"  # Remove each date file if it exists
+        done
+    else
+        echo "Skipping: No 'date' files found in prebuilts/build-tools/path/*/"
+    fi
+
+    if ls prebuilts/build-tools/path/*/tar >/dev/null 2>&1; then
+        for file in prebuilts/build-tools/path/*/tar; do
+            rm -f "$file"  # Remove each tar file if it exists
+        done
+    else
+        echo "Skipping: No 'tar' files found in prebuilts/build-tools/path/*/"
+    fi
 }
 
 remove_broken_build_tools


### PR DESCRIPTION
- Add checks to avoid "no matches found" errors for missing `date` and `tar` files
- Print "Skipping" message when no files are found, improving feedback

if this is not applied you get:

`remove_broken_build_tools:1: no matches found: prebuilts/build-tools/path/*/date`

Change-Id: Ibbd74f6e225bdb4b43e3e81508a306364cc2dcca
