### PR TITLE
build: Fix reading build props on devices with legacy partition layout

### DIFF
--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -1104,8 +1104,9 @@ class PartitionBuildProps(object):
     Return empty string if not found.
     """
     data = ''
-    for prop_file in ['{}/etc/build.prop'.format(name.upper()),
-                      '{}/build.prop'.format(name.upper())]:
+    partition_map = PartitionMapFromTargetFiles(input_file)
+    for prop_file in ['{}/etc/build.prop'.format(partition_map[name]),
+                      '{}/build.prop'.format(partition_map[name])]:
       try:
         data = ReadFromInputFile(input_file, prop_file)
         break


### PR DESCRIPTION
[`Issue`]
With If4e77019427793b5c1f3dec9fc938ac3e3270c26 some system properties were moved to product partition. As a result building OTA package fails due to unresolvable build props.

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/mnt/out/host/linux-x86/bin/ota_from_target_files/__main__.py", line 52, in <module>
  File "/mnt/out/host/linux-x86/bin/ota_from_target_files/__main__.py", line 46, in _soong_main
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "ota_from_target_files.py", line 1541, in <module>
  File "ota_from_target_files.py", line 1518, in main
  File "non_ab_ota.py", line 660, in GenerateNonAbOtaPackage
  File "non_ab_ota.py", line 232, in WriteFullOTAPackage
  File "common.py", line 565, in GetBuildProp
  File "common.py", line 602, in _ResolveRoProductBuildProp
common.ExternalError: couldn't resolve ro.crdroid.build.version
```

[`Explanation`]
The existing implementation of `ota_from_target_files` scans for partition build props strictly in paths:
- `$(PRODUCT_OUT)/{partname}/build.prop` (`PRODUCT_OUT = out/target/product/{product_name}`)
- `$(PRODUCT_OUT)/{partname}/etc/build.prop`

But the legacy devices launched before Android 11 have separate partitions only for system (`$(PRODUCT_OUT)/system`) and vendor (`$(PRODUCT_OUT)/vendor`), but not for product (`$(PRODUCT_OUT)/product`) or system_ext (`$(PRODUCT_OUT)/system_ext`) unless dynamic partitioning is implemented. So, their `TARGET_COPY_OUT_*` aren't relative to the staging directory, i.e., `$(PRODUCT_OUT)`, instead, they are all coupled with the system partition, and the partition target files will be located under `$(PRODUCT_OUT)/system/{partname}` rather then `$(PRODUCT_OUT)/{partname}`.

[`Fix`]
To cover all possible partition name variations and locations, use the already existing `PartitionMapFromTargetFiles()` helper function to dynamically determine the correct path for each partition, so that `ota_from_target_files` resolves build.prop files using `$(PRODUCT_OUT)/system/product` as a base path instead of `$(PRODUCT_OUT)/product` when appropriate.